### PR TITLE
proc_terminate before proc_close

### DIFF
--- a/bot.php
+++ b/bot.php
@@ -74,6 +74,7 @@ $str = $zug;
 
 fclose($pipes[0]);
 fclose($pipes[1]);
+proc_terminate($process);
 proc_close($process);
 
 }


### PR DESCRIPTION
its good to use proc_terminate before proc_close, to make sure the engine properly shutdown.

because its use UCI interface, i use your code a lot in my college project :-D and try to use some engine other than stockfish, i notice some engine not properly closed if not terminated first, like gnuchess

thank you
